### PR TITLE
Compat with Ubuntu 22.04+ / libfluidsynth3

### DIFF
--- a/NFluidsynth.Sample/NFluidsynth.Sample.csproj
+++ b/NFluidsynth.Sample/NFluidsynth.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Copyright>atsushi</Copyright>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/NFluidsynth.Sample/Program.cs
+++ b/NFluidsynth.Sample/Program.cs
@@ -2,6 +2,7 @@
 using NFluidsynth;
 using System.Threading;
 using System.Linq;
+using System.IO;
 
 namespace NFluidsynth.Sample
 {
@@ -21,7 +22,19 @@ namespace NFluidsynth.Sample
                         if (SoundFont.IsSoundFont(arg))
                             syn.LoadSoundFont(arg, true);
                     if (syn.FontCount == 0)
-                        syn.LoadSoundFont("/usr/share/sounds/sf2/FluidR3_GM.sf2", true);
+                    {                        
+                        const string SOUND_FONT_UBUNTU_14_04 = "/usr/share/sounds/sf2/FluidR3_GS.sf2";
+                        const string SOUND_FONT_UBUNTU_22_10 = "/usr/share/sounds/sf2/FluidR3_GM.sf2";
+                        if (File.Exists(SOUND_FONT_UBUNTU_14_04))
+                            syn.LoadSoundFont(SOUND_FONT_UBUNTU_14_04, true);
+                        else if (File.Exists(SOUND_FONT_UBUNTU_22_10))
+                            syn.LoadSoundFont(SOUND_FONT_UBUNTU_22_10, true);
+                        else
+                        {
+                            System.Console.WriteLine("No system sound font file found.");
+                            return;
+                        }
+                    }
                     for (int i = 0; i < 16; i++)
                         syn.SoundFontSelect(i, 0);
                     var files = args.Where(SoundFont.IsMidiFile);

--- a/NFluidsynth.Tests/NFluidsynth.Tests.csproj
+++ b/NFluidsynth.Tests/NFluidsynth.Tests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.15.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.16.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.0-beta.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NFluidsynth\NFluidsynth.csproj" />

--- a/NFluidsynth.Tests/SynthTest.cs
+++ b/NFluidsynth.Tests/SynthTest.cs
@@ -53,7 +53,16 @@ namespace NFluidsynth.Tests
             using (var syn = new Synth(NewAlsaSettings()))
             using (var audio = new AudioDriver(syn.Settings, syn))
             {
-                syn.LoadSoundFont("/usr/share/sounds/sf2/FluidR3_GS.sf2", false);
+                const string SOUND_FONT_UBUNTU_14_04 = "/usr/share/sounds/sf2/FluidR3_GS.sf2";
+                const string SOUND_FONT_UBUNTU_22_10 = "/usr/share/sounds/sf2/FluidR3_GM.sf2";
+                if (File.Exists(SOUND_FONT_UBUNTU_14_04))
+                    syn.LoadSoundFont(SOUND_FONT_UBUNTU_14_04, false);
+                else if (File.Exists(SOUND_FONT_UBUNTU_22_10))
+                    syn.LoadSoundFont(SOUND_FONT_UBUNTU_22_10, false);
+                else
+                {
+                    Assert.Fail("No system sound font file found.");
+                }
                 Assert.AreEqual(1, syn.FontCount, "FontCount");
                 for (int i = 0; i < 16; i++)
                     syn.SoundFontSelect(i, 1);

--- a/NFluidsynth/NFluidsynth.csproj
+++ b/NFluidsynth/NFluidsynth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <Version>0.1.0</Version>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <Version>0.1.1</Version>
     <AssemblyName>SpaceWizards.NFluidsynth</AssemblyName>
     <RootNamespace>NFluidsynth</RootNamespace>
     <IncludeSymbols>true</IncludeSymbols>

--- a/NFluidsynth/Native/LibFluidsynth.SequencerEvent.cs
+++ b/NFluidsynth/Native/LibFluidsynth.SequencerEvent.cs
@@ -51,10 +51,10 @@ namespace NFluidsynth.Native
         [DllImport(LibraryName)]
         internal static extern void fluid_event_bank_select(fluid_event_t_ptr evt, int channel, short bank_num);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_program_change")]
         internal static extern void fluid_event_program_change_2(fluid_event_t_ptr evt, int channel, short preset_num);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_program_change")]
         internal static extern void fluid_event_program_change_3(fluid_event_t_ptr evt, int channel, int preset_num);
 
         [DllImport(LibraryName)]
@@ -62,11 +62,11 @@ namespace NFluidsynth.Native
             sfont_id, short bank_num, short preset_num);
 
         /* Real-time generic instrument controllers */
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_control_change")]
         internal static extern
             void fluid_event_control_change_2(fluid_event_t_ptr evt, int channel, short control, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_control_change")]
         internal static extern
             void fluid_event_control_change_3(fluid_event_t_ptr evt, int channel, short control, int val);
 
@@ -74,58 +74,58 @@ namespace NFluidsynth.Native
         [DllImport(LibraryName)]
         internal static extern void fluid_event_pitch_bend(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_pitch_wheelsens")]
         internal static extern void fluid_event_pitch_wheelsens_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_pitch_wheelsens")]
         internal static extern void fluid_event_pitch_wheelsens_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_modulation")]
         internal static extern void fluid_event_modulation_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_modulation")]
         internal static extern void fluid_event_modulation_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_sustain")]
         internal static extern void fluid_event_sustain_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_sustain")]
         internal static extern void fluid_event_sustain_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_pan")]
         internal static extern void fluid_event_pan_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_pan")]
         internal static extern void fluid_event_pan_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_volume")]
         internal static extern void fluid_event_volume_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_volume")]
         internal static extern void fluid_event_volume_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_reverb_send")]
         internal static extern void fluid_event_reverb_send_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_reverb_send")]
         internal static extern void fluid_event_reverb_send_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_chorus_send")]
         internal static extern void fluid_event_chorus_send_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_chorus_send")]
         internal static extern void fluid_event_chorus_send_3(fluid_event_t_ptr evt, int channel, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_key_pressure")]
         internal static extern void fluid_event_key_pressure_2(fluid_event_t_ptr evt, int channel, short key, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_key_pressure")]
         internal static extern void fluid_event_key_pressure_3(fluid_event_t_ptr evt, int channel, short key, int val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_channel_pressure")]
         internal static extern void fluid_event_channel_pressure_2(fluid_event_t_ptr evt, int channel, short val);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_channel_pressure")]
         internal static extern void fluid_event_channel_pressure_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
@@ -133,7 +133,7 @@ namespace NFluidsynth.Native
 
 
         /* Only for removing events */
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_any_control_change")]
         internal static extern void fluid_event_any_control_change_2(fluid_event_t_ptr evt, int channel);
 
         /* Only when unregistering clients */
@@ -162,16 +162,16 @@ namespace NFluidsynth.Native
         [DllImport(LibraryName)]
         internal static extern short fluid_event_get_control(fluid_event_t_ptr evt);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_get_value")]
         internal static extern short fluid_event_get_value_2(fluid_event_t_ptr evt);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_get_value")]
         internal static extern int fluid_event_get_value_3(fluid_event_t_ptr evt);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_get_program")]
         internal static extern short fluid_event_get_program_2(fluid_event_t_ptr evt);
 
-        [DllImport(LibraryName)]
+        [DllImport(LibraryName, EntryPoint="fluid_event_get_program")]
         internal static extern int fluid_event_get_program_3(fluid_event_t_ptr evt);
 
         [DllImport(LibraryName)]

--- a/NFluidsynth/Native/LibFluidsynth.SequencerEvent.cs
+++ b/NFluidsynth/Native/LibFluidsynth.SequencerEvent.cs
@@ -52,7 +52,10 @@ namespace NFluidsynth.Native
         internal static extern void fluid_event_bank_select(fluid_event_t_ptr evt, int channel, short bank_num);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_program_change(fluid_event_t_ptr evt, int channel, short preset_num);
+        internal static extern void fluid_event_program_change_2(fluid_event_t_ptr evt, int channel, short preset_num);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_program_change_3(fluid_event_t_ptr evt, int channel, int preset_num);
 
         [DllImport(LibraryName)]
         internal static extern void fluid_event_program_select(fluid_event_t_ptr evt, int channel, uint
@@ -61,38 +64,69 @@ namespace NFluidsynth.Native
         /* Real-time generic instrument controllers */
         [DllImport(LibraryName)]
         internal static extern
-            void fluid_event_control_change(fluid_event_t_ptr evt, int channel, short control, short val);
+            void fluid_event_control_change_2(fluid_event_t_ptr evt, int channel, short control, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern
+            void fluid_event_control_change_3(fluid_event_t_ptr evt, int channel, short control, int val);
 
         /* Real-time instrument controllers shortcuts */
         [DllImport(LibraryName)]
         internal static extern void fluid_event_pitch_bend(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_pitch_wheelsens(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_pitch_wheelsens_2(fluid_event_t_ptr evt, int channel, short val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_modulation(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_pitch_wheelsens_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_sustain(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_modulation_2(fluid_event_t_ptr evt, int channel, short val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_pan(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_modulation_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_volume(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_sustain_2(fluid_event_t_ptr evt, int channel, short val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_reverb_send(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_sustain_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_chorus_send(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_pan_2(fluid_event_t_ptr evt, int channel, short val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_key_pressure(fluid_event_t_ptr evt, int channel, short key, short val);
+        internal static extern void fluid_event_pan_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_channel_pressure(fluid_event_t_ptr evt, int channel, short val);
+        internal static extern void fluid_event_volume_2(fluid_event_t_ptr evt, int channel, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_volume_3(fluid_event_t_ptr evt, int channel, int val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_reverb_send_2(fluid_event_t_ptr evt, int channel, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_reverb_send_3(fluid_event_t_ptr evt, int channel, int val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_chorus_send_2(fluid_event_t_ptr evt, int channel, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_chorus_send_3(fluid_event_t_ptr evt, int channel, int val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_key_pressure_2(fluid_event_t_ptr evt, int channel, short key, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_key_pressure_3(fluid_event_t_ptr evt, int channel, short key, int val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_channel_pressure_2(fluid_event_t_ptr evt, int channel, short val);
+
+        [DllImport(LibraryName)]
+        internal static extern void fluid_event_channel_pressure_3(fluid_event_t_ptr evt, int channel, int val);
 
         [DllImport(LibraryName)]
         internal static extern void fluid_event_system_reset(fluid_event_t_ptr evt);
@@ -100,7 +134,7 @@ namespace NFluidsynth.Native
 
         /* Only for removing events */
         [DllImport(LibraryName)]
-        internal static extern void fluid_event_any_control_change(fluid_event_t_ptr evt, int channel);
+        internal static extern void fluid_event_any_control_change_2(fluid_event_t_ptr evt, int channel);
 
         /* Only when unregistering clients */
         [DllImport(LibraryName)]
@@ -129,10 +163,16 @@ namespace NFluidsynth.Native
         internal static extern short fluid_event_get_control(fluid_event_t_ptr evt);
 
         [DllImport(LibraryName)]
-        internal static extern short fluid_event_get_value(fluid_event_t_ptr evt);
+        internal static extern short fluid_event_get_value_2(fluid_event_t_ptr evt);
 
         [DllImport(LibraryName)]
-        internal static extern short fluid_event_get_program(fluid_event_t_ptr evt);
+        internal static extern int fluid_event_get_value_3(fluid_event_t_ptr evt);
+
+        [DllImport(LibraryName)]
+        internal static extern short fluid_event_get_program_2(fluid_event_t_ptr evt);
+
+        [DllImport(LibraryName)]
+        internal static extern int fluid_event_get_program_3(fluid_event_t_ptr evt);
 
         [DllImport(LibraryName)]
         internal static extern void* fluid_event_get_data(fluid_event_t_ptr evt);

--- a/NFluidsynth/Native/LibFluidsynth.SfLoader.cs
+++ b/NFluidsynth/Native/LibFluidsynth.SfLoader.cs
@@ -26,13 +26,19 @@ namespace NFluidsynth.Native
 
         internal delegate IntPtr fluid_sfloader_callback_open_t(string filename);
 
-        internal delegate int fluid_sfloader_callback_read_t(IntPtr buf, int count, IntPtr handle);
+        internal delegate int fluid_sfloader_callback_read_t_2(IntPtr buf, int count, IntPtr handle);
 
-        internal delegate int fluid_sfloader_callback_seek_t(IntPtr handle, int offset, int origin);
+        internal delegate int fluid_sfloader_callback_read_t_3(IntPtr buf, long count, IntPtr handle);
+
+        internal delegate int fluid_sfloader_callback_seek_t_2(IntPtr handle, int offset, int origin);
+
+        internal delegate int fluid_sfloader_callback_seek_t_3(IntPtr handle, long offset, int origin);
 
         internal delegate int fluid_sfloader_callback_close_t(IntPtr handle);
 
-        internal delegate int fluid_sfloader_callback_tell_t(IntPtr handle);
+        internal delegate int fluid_sfloader_callback_tell_t_2(IntPtr handle);
+
+        internal delegate long fluid_sfloader_callback_tell_t_3(IntPtr handle);
 
         [DllImport(LibraryName)]
         internal static extern int fluid_sfloader_set_callbacks(fluid_sfloader_t_ptr loader,

--- a/NFluidsynth/Native/LibFluidsynth.cs
+++ b/NFluidsynth/Native/LibFluidsynth.cs
@@ -22,8 +22,11 @@ namespace NFluidsynth.Native
                     {
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                         {
-                            // Assumption here is that this binds against whatever API .2 is,
+                            // Assumption here is that this binds against whatever API .3 is,
                             //  but will try the general name anyway just in case.
+                            if (NativeLibrary.TryLoad("libfluidsynth.so.3", assembly, path, out handle))
+                                return handle;
+
                             if (NativeLibrary.TryLoad("libfluidsynth.so.2", assembly, path, out handle))
                                 return handle;
 

--- a/NFluidsynth/Native/LibFluidsynth.cs
+++ b/NFluidsynth/Native/LibFluidsynth.cs
@@ -7,6 +7,24 @@ namespace NFluidsynth.Native
     {
         public const string LibraryName = "fluidsynth";
 
+        /**
+        * Supports both ABI 2 and ABI 3 of Fluid Synth
+        * https://abi-laboratory.pro/index.php?view=timeline&l=fluidsynth
+        */
+        public static int LibraryVersion 
+        { 
+            get
+            {
+                return _libraryVersion;
+            }
+            
+            private set
+            {
+                _libraryVersion = value;
+            }
+        }
+        private static int _libraryVersion = 2; // Assume using ABI 2 unless detecting otherwise
+
         public const int FluidOk = 0;
         public const int FluidFailed = -1;
 
@@ -25,7 +43,10 @@ namespace NFluidsynth.Native
                             // Assumption here is that this binds against whatever API .3 is,
                             //  but will try the general name anyway just in case.
                             if (NativeLibrary.TryLoad("libfluidsynth.so.3", assembly, path, out handle))
+                            {
+                                LibFluidsynth.LibraryVersion = 3;
                                 return handle;
+                            }
 
                             if (NativeLibrary.TryLoad("libfluidsynth.so.2", assembly, path, out handle))
                                 return handle;

--- a/NFluidsynth/Native/LibFluidsynth.cs
+++ b/NFluidsynth/Native/LibFluidsynth.cs
@@ -7,10 +7,8 @@ namespace NFluidsynth.Native
     {
         public const string LibraryName = "fluidsynth";
 
-        /**
-        * Supports both ABI 2 and ABI 3 of Fluid Synth
-        * https://abi-laboratory.pro/index.php?view=timeline&l=fluidsynth
-        */
+        // Supports both ABI 2 and ABI 3 of Fluid Synth
+        // https://abi-laboratory.pro/index.php?view=timeline&l=fluidsynth
         public static int LibraryVersion 
         { 
             get

--- a/NFluidsynth/SequencerEvent.cs
+++ b/NFluidsynth/SequencerEvent.cs
@@ -100,21 +100,29 @@ namespace NFluidsynth
             }
         }
 
-        public short Value
+        public int Value
         {
             get
             {
                 ThrowIfDisposed();
-                return LibFluidsynth.fluid_event_get_value(Handle);
+
+                if (LibFluidsynth.LibraryVersion == 2)
+                    return LibFluidsynth.fluid_event_get_value_2(Handle);
+                else 
+                    return LibFluidsynth.fluid_event_get_value_3(Handle);
             }
         }
 
-        public short Program
+        public int Program
         {
             get
             {
                 ThrowIfDisposed();
-                return LibFluidsynth.fluid_event_get_program(Handle);
+
+                if (LibFluidsynth.LibraryVersion == 2)
+                    return LibFluidsynth.fluid_event_get_program_2(Handle);
+                else
+                    return LibFluidsynth.fluid_event_get_program_3(Handle);
             }
         }
 
@@ -208,7 +216,11 @@ namespace NFluidsynth
         public void ProgramChange(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_program_change(Handle, channel, val);
+            
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_program_change_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_program_change_3(Handle, channel, val);
         }
 
         public void ProgramSelect(int channel, uint soundFontId, short bankNum, short presetNum)
@@ -220,7 +232,11 @@ namespace NFluidsynth
         public void ControlChange(int channel, short control, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_control_change(Handle, channel, control, val);
+            
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_control_change_2(Handle, channel, control, val);
+            else
+                LibFluidsynth.fluid_event_control_change_3(Handle, channel, control, val);
         }
 
         public void PitchBend(int channel, int pitch)
@@ -232,67 +248,97 @@ namespace NFluidsynth
         public void PitchWheelSensitivity(int channel, short value)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_pitch_wheelsens(Handle, channel, value);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_pitch_wheelsens_2(Handle, channel, value);
+            else
+                LibFluidsynth.fluid_event_pitch_wheelsens_3(Handle, channel, value);
         }
 
         public void Modulation(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_modulation(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_modulation_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_modulation_3(Handle, channel, val);
         }
 
         public void Sustain(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_sustain(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_sustain_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_sustain_3(Handle, channel, val);
         }
 
         public void Pan(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_pan(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_pan_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_pan_3(Handle, channel, val);
         }
 
         public void Volume(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_volume(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_volume_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_volume_3(Handle, channel, val);
         }
 
         public void ReverbSend(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_reverb_send(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_reverb_send_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_reverb_send_3(Handle, channel, val);
         }
 
         public void ChorusSend(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_chorus_send(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_chorus_send_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_chorus_send_3(Handle, channel, val);
         }
 
         public void KeyPressure(int channel, short key, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_key_pressure(Handle, channel, key, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_key_pressure_2(Handle, channel, key, val);
+            else
+                LibFluidsynth.fluid_event_key_pressure_3(Handle, channel, key, val);
         }
 
         public void ChannelPressure(int channel, short val)
         {
             ThrowIfDisposed();
-            LibFluidsynth.fluid_event_channel_pressure(Handle, channel, val);
+
+            if (LibFluidsynth.LibraryVersion == 2)
+                LibFluidsynth.fluid_event_channel_pressure_2(Handle, channel, val);
+            else
+                LibFluidsynth.fluid_event_channel_pressure_3(Handle, channel, val);
         }
 
         public void SystemReset()
         {
             ThrowIfDisposed();
             LibFluidsynth.fluid_event_system_reset(Handle);
-        }
-
-        public void AnyControlChange(int channel)
-        {
-            ThrowIfDisposed();
-            LibFluidsynth.fluid_event_any_control_change(Handle, channel);
         }
 
         public void Unregistering()

--- a/NFluidsynth/SoundFontLoader.cs
+++ b/NFluidsynth/SoundFontLoader.cs
@@ -18,15 +18,18 @@ namespace NFluidsynth
         // used as fluid_sfloader_callback_read_t
         public abstract int Read(IntPtr buf, long count, IntPtr sfHandle);
 
-        public int Read(IntPtr buf, int count, IntPtr sfHandle) => Read(buf, (long) count, sfHandle);
+        public int Read_2(IntPtr buf, int count, IntPtr sfHandle) => Read(buf, (long) count, sfHandle);
+        public int Read_3(IntPtr buf, long count, IntPtr sfHandle) => Read(buf, count, sfHandle);
 
         // used as fluid_sfloader_callback_seek_t
-        public abstract int Seek(IntPtr sfHandle, int offset, SeekOrigin origin);
+        public abstract int Seek(IntPtr sfHandle, long offset, SeekOrigin origin);
 
-        public int Seek(IntPtr sfHandle, int offset, int origin) => Seek(sfHandle, offset, (SeekOrigin) origin);
+        public int Seek_2(IntPtr sfHandle, int offset, int origin) => Seek(sfHandle, (long) offset, (SeekOrigin) origin);
+        public int Seek_3(IntPtr sfHandle, long offset, int origin) => Seek(sfHandle, offset, (SeekOrigin) origin);
 
         // used as fluid_sfloader_callback_tell_t
-        public abstract int Tell(IntPtr sfHandle);
+        public abstract long Tell(IntPtr sfHandle);
+        public int Tell_2(IntPtr sfHandle) { return (int) Tell(sfHandle); }
 
         // used as fluid_sfloader_callback_close_t
         public abstract int Close(IntPtr sfHandle);
@@ -38,9 +41,12 @@ namespace NFluidsynth
 
         // We keep these around so the GC doesn't eat them.
         private fluid_sfloader_callback_open_t _open;
-        private fluid_sfloader_callback_read_t _read;
-        private fluid_sfloader_callback_seek_t _seek;
-        private fluid_sfloader_callback_tell_t _tell;
+        private fluid_sfloader_callback_read_t_2 _read_2;
+        private fluid_sfloader_callback_read_t_3 _read_3;
+        private fluid_sfloader_callback_seek_t_2 _seek_2;
+        private fluid_sfloader_callback_seek_t_3 _seek_3;
+        private fluid_sfloader_callback_tell_t_2 _tell_2;
+        private fluid_sfloader_callback_tell_t_3 _tell_3;
         private fluid_sfloader_callback_close_t _close;
 
         public static SoundFontLoader NewDefaultSoundFontLoader(Settings settings)
@@ -62,12 +68,22 @@ namespace NFluidsynth
 
         public unsafe void SetCallbacks(SoundFontLoaderCallbacks callbacks)
         {
-            fluid_sfloader_set_callbacks(handle,
-                Utility.PassDelegatePointer(callbacks.Open, out _open),
-                Utility.PassDelegatePointer(callbacks.Read, out _read),
-                Utility.PassDelegatePointer(callbacks.Seek, out _seek),
-                Utility.PassDelegatePointer(callbacks.Tell, out _tell),
-                Utility.PassDelegatePointer(callbacks.Close, out _close));
+            if (LibraryVersion == 2)
+            {
+                fluid_sfloader_set_callbacks(handle,
+                    Utility.PassDelegatePointer(callbacks.Open, out _open),
+                    Utility.PassDelegatePointer(callbacks.Read_2, out _read_2),
+                    Utility.PassDelegatePointer(callbacks.Seek_2, out _seek_2),
+                    Utility.PassDelegatePointer(callbacks.Tell_2, out _tell_2),
+                    Utility.PassDelegatePointer(callbacks.Close, out _close));
+            } else {
+                fluid_sfloader_set_callbacks(handle,
+                    Utility.PassDelegatePointer(callbacks.Open, out _open),
+                    Utility.PassDelegatePointer(callbacks.Read_3, out _read_3),
+                    Utility.PassDelegatePointer(callbacks.Seek_3, out _seek_3),
+                    Utility.PassDelegatePointer(callbacks.Tell, out _tell_3),
+                    Utility.PassDelegatePointer(callbacks.Close, out _close));
+            }
         }
 
         public virtual void Dispose()


### PR DESCRIPTION
This PR makes MIDI audio work in recent linux distros -- in particular, the latest Ubuntu 22.10 (but also looks like this was probably broken in 22.04LTS)

On Ubuntu 22.04+, the package is now [libfluidsynth3](https://packages.ubuntu.com/kinetic/libfluidsynth3) with the older [libfluidsynth2](https://packages.ubuntu.com/search?suite=focal&searchon=names&keywords=libfluidsynth2) no longer being available.    (Note filename has [changed](https://packages.ubuntu.com/kinetic/amd64/libfluidsynth3/filelist) to be `so.3` instead of `so.2`)

The main change is `NFluidsynth/Native/LibFluidsynth.cs` to have it check for and use `libfluidsynth.so.3` if it's installed.

I also made some other changes to help compat with recent linux in general:

- Removed EOL'ed net versions and replaced with net7 to make warnings go away
- The sound bank file has changed on linux, so point to the new one for sample + test (or fallback to old one)
- Update some dependency versions
- Could not get the tests to run [at all](https://stackoverflow.com/a/53132052/15772993) without NUnit3TestAdapter, so added that (must be the beta version, stable version doesn't work)

Notes / caveats:

1) While most of the tests work again (yay!), two of the tests still fail.  The file comment indicates they were specifically written for ubuntu 14 (!), so probably more work is needed to get those tests fully up to date.  But I wasn't too sure about how to fix this, and the basics were working so I'll leave this for now.

2) There is a bug I noticed:  in-game, at the end of a song (or when pressing stop), the system plays the last note again after the song is complete.  It happens when these messages are displayed:
```
[DEBG] midi: 00005442:            SystemReset chan:00 key:00000 bank:00 ctrl:00000 dur:00000 pitch:00000 prog:000 val:00000 vel:00000
[DEBG] clyde.oal: Cleaning out buffered source 2 which finalized in another thread.
[DEBG] midi: 00001818:            SystemReset chan:00 key:00000 bank:00 ctrl:00000 dur:00000 pitch:00000 prog:000 val:00000 vel:00000
[DEBG] clyde.oal: Cleaning out buffered source 4 which finalized in another thread.
```
This particular bug may not be linux related at all.  This didn't happen with the standalone sample which just plays a single note, so I think it's a game-specific issue as opposed to something with libfluidsynth.  Further testing would be needed, but given it's relatively minor compared to having no MIDI at all, I figured it was worth pressing ahead.
