### PR TITLE
Windows ABI V3 support, other fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET 7.0.X
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 9.0.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/NFluidsynth.Sample/NFluidsynth.Sample.csproj
+++ b/NFluidsynth.Sample/NFluidsynth.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Copyright>atsushi</Copyright>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/NFluidsynth.Sample/Program.cs
+++ b/NFluidsynth.Sample/Program.cs
@@ -22,10 +22,9 @@ namespace NFluidsynth.Sample
             {
                 using (var syn = new Synth(settings))
                 {
-                    foreach (var arg in from arg in args where SoundFont.IsSoundFont(arg) select arg)
-                    {
-                        syn.LoadSoundFont(arg, true);
-                    }
+                    foreach (var arg in args)
+                        if (SoundFont.IsSoundFont(arg))
+                            syn.LoadSoundFont(arg, true);
 
                     if (syn.FontCount == 0 && !LoadDefaultSoundfont(syn))
                         return;

--- a/NFluidsynth.Sample/Program.cs
+++ b/NFluidsynth.Sample/Program.cs
@@ -13,10 +13,6 @@ namespace NFluidsynth.Sample
 
         private const string WINDOWS_GM_DEFAULT_SOUNDFONT = @"C:\WINDOWS\SYSTEM32\DRIVERS\GM.DLS";
 
-        // Is this even correct? Who knows. This is pulled from a random forum post.
-        // Someone with a Mac can check.
-        // Of course this is Apple so it probably changes directories randomly 
-        // just to mess with developers.
         private const string OSX_GS_DEFAULT_SOUNDFONT =
             "/System/Library/Components/CoreAudio.component/Contents/Resources/gs_instruments.dls";
 

--- a/NFluidsynth.Sample/Program.cs
+++ b/NFluidsynth.Sample/Program.cs
@@ -1,70 +1,101 @@
 ﻿using System;
-using NFluidsynth;
 using System.Threading;
 using System.Linq;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace NFluidsynth.Sample
 {
-    public class Program
+    public static class Program
     {
+        private const string LINUX_GS_DEFAULT_SOUNDFONT = "/usr/share/sounds/sf2/FluidR3_GS.sf2";
+        private const string LINUX_GM_DEFAULT_SOUNDFONT = "/usr/share/sounds/sf2/FluidR3_GM.sf2";
+
+        private const string WINDOWS_GM_DEFAULT_SOUNDFONT = @"C:\WINDOWS\SYSTEM32\DRIVERS\GM.DLS";
+
+        // Is this even correct? Who knows. This is pulled from a random forum post.
+        // Someone with a Mac can check.
+        // Of course this is Apple so it probably changes directories randomly 
+        // just to mess with developers.
+        private const string OSX_GS_DEFAULT_SOUNDFONT =
+            "/System/Library/Components/CoreAudio.component/Contents/Resources/gs_instruments.dls";
+
         public static void Main(string[] args)
         {
             using (var settings = new Settings())
             {
-                // Change this if you don't have pulseaudio or want to change to anything else.
-                if (Environment.OSVersion.Platform == PlatformID.Unix)
-                    settings[ConfigurationKeys.AudioDriver].StringValue = "pulseaudio";
-                settings[ConfigurationKeys.SynthAudioChannels].IntValue = 2;
                 using (var syn = new Synth(settings))
                 {
-                    foreach (var arg in args)
-                        if (SoundFont.IsSoundFont(arg))
-                            syn.LoadSoundFont(arg, true);
-                    if (syn.FontCount == 0)
-                    {                        
-                        const string SOUND_FONT_UBUNTU_14_04 = "/usr/share/sounds/sf2/FluidR3_GS.sf2";
-                        const string SOUND_FONT_UBUNTU_22_10 = "/usr/share/sounds/sf2/FluidR3_GM.sf2";
-                        if (File.Exists(SOUND_FONT_UBUNTU_14_04))
-                            syn.LoadSoundFont(SOUND_FONT_UBUNTU_14_04, true);
-                        else if (File.Exists(SOUND_FONT_UBUNTU_22_10))
-                            syn.LoadSoundFont(SOUND_FONT_UBUNTU_22_10, true);
-                        else
-                        {
-                            System.Console.WriteLine("No system sound font file found.");
-                            return;
-                        }
+                    foreach (var arg in from arg in args where SoundFont.IsSoundFont(arg) select arg)
+                    {
+                        syn.LoadSoundFont(arg, true);
                     }
-                    for (int i = 0; i < 16; i++)
+
+                    if (syn.FontCount == 0 && !LoadDefaultSoundfont(syn))
+                        return;
+
+                    for (var i = 0; i < 16; i++)
                         syn.SoundFontSelect(i, 0);
-                    var files = args.Where(SoundFont.IsMidiFile);
-                    if (files.Any())
+
+                    var files = args.Where(SoundFont.IsMidiFile).ToList();
+
+                    if (files.Count == 0)
                     {
-                        foreach (var arg in files)
-                        {
-                            using (var player = new Player(syn))
-                            {
-                                using (var adriver = new AudioDriver(syn.Settings, syn))
-                                {
-                                    player.Add(arg);
-                                    player.Play();
-                                    player.Join();
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        using (var adriver = new AudioDriver(syn.Settings, syn))
+                        using (new AudioDriver(syn.Settings, syn))
                         {
                             syn.ProgramChange(0, 1);
                             syn.NoteOn(0, 60, 120);
-                            Thread.Sleep(5000);
+                            Thread.Sleep(500);
                             syn.NoteOff(0, 60);
+                        }
+
+                        return;
+                    }
+
+                    foreach (var arg in files)
+                    {
+                        using (var player = new Player(syn))
+                        {
+                            using (new AudioDriver(syn.Settings, syn))
+                            {
+                                player.Add(arg);
+                                player.Play();
+                                player.Join();
+                            }
                         }
                     }
                 }
             }
+        }
+
+        private static bool LoadDefaultSoundfont(Synth syn)
+        {
+            var soundfontPath = "";
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (File.Exists(LINUX_GS_DEFAULT_SOUNDFONT))
+                    soundfontPath = LINUX_GS_DEFAULT_SOUNDFONT;
+                else if (File.Exists(LINUX_GM_DEFAULT_SOUNDFONT))
+                    soundfontPath = LINUX_GM_DEFAULT_SOUNDFONT;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && File.Exists(OSX_GS_DEFAULT_SOUNDFONT))
+                soundfontPath = OSX_GS_DEFAULT_SOUNDFONT;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && File.Exists(WINDOWS_GM_DEFAULT_SOUNDFONT))
+                soundfontPath = WINDOWS_GM_DEFAULT_SOUNDFONT;
+
+            if (soundfontPath == "")
+            {
+                Console.WriteLine("No system sound font file found.");
+
+                return false;
+            }
+
+            syn.LoadSoundFont(soundfontPath, true);
+
+            return true;
         }
     }
 }

--- a/NFluidsynth.Tests/NFluidsynth.Tests.csproj
+++ b/NFluidsynth.Tests/NFluidsynth.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/NFluidsynth/FluidSynthInteropException.cs
+++ b/NFluidsynth/FluidSynthInteropException.cs
@@ -1,28 +1,10 @@
 using System;
-using NFluidsynth.Native;
-using System.Runtime.Serialization;
 
-namespace NFluidsynth
+namespace NFluidsynth;
+
+public class FluidSynthInteropException(string message) : Exception(message)
 {
-    public class FluidSynthInteropException : Exception
-    {
-        public FluidSynthInteropException() : this("Fluidsynth native error")
-        {
-        }
-
-        public FluidSynthInteropException(string message) : base(message)
-        {
-        }
-
-
-#if !PORTABLE
-        public FluidSynthInteropException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
-#endif
-
-        public FluidSynthInteropException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-    }
+  public FluidSynthInteropException() : this("Fluidsynth native error")
+  {
+  }
 }

--- a/NFluidsynth/NFluidsynth.csproj
+++ b/NFluidsynth/NFluidsynth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <Version>0.1.1</Version>
     <AssemblyName>SpaceWizards.NFluidsynth</AssemblyName>
     <RootNamespace>NFluidsynth</RootNamespace>

--- a/NFluidsynth/Native/LibFluidsynth.Misc.cs
+++ b/NFluidsynth/Native/LibFluidsynth.Misc.cs
@@ -5,13 +5,13 @@ namespace NFluidsynth.Native
 {
     internal static partial class LibFluidsynth
     {
-        [DllImport(LibraryName)]
-        internal static extern int fluid_is_soundfont([MarshalAs(LP_Str)] string filename);
+        [LibraryImport(LibraryName)]
+        internal static partial int fluid_is_soundfont([MarshalAs(LP_Str)] string filename);
 
-        [DllImport(LibraryName)]
-        internal static extern int fluid_is_midifile([MarshalAs(LP_Str)] string filename);
+        [LibraryImport(LibraryName)]
+        internal static partial int fluid_is_midifile([MarshalAs(LP_Str)] string filename);
 
-        [DllImport(LibraryName)]
-        internal static extern IntPtr fluid_set_log_function(int severity, Logger.LoggerDelegate func, IntPtr data);
+        [LibraryImport(LibraryName)]
+        internal static partial IntPtr fluid_set_log_function(int severity, Logger.LoggerDelegate func, IntPtr data);
     }
 }

--- a/NFluidsynth/Native/LibFluidsynth.cs
+++ b/NFluidsynth/Native/LibFluidsynth.cs
@@ -67,25 +67,15 @@ internal static partial class LibFluidsynth
 
     private static IntPtr TryLoadLinux(System.Reflection.Assembly assembly, DllImportSearchPath? path)
     {
-        foreach (var name in LINUX_FLUIDSYNTH_ABI_V3_DLL_NAMES)
-        {
-            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
-                continue;
-
+        if (TryLoadDll(assembly, path, LINUX_FLUIDSYNTH_ABI_V3_DLL_NAMES, out var handle)) {
             LibraryVersion = FluidSynthAbiVersion.V3;
 
             return handle;
         }
 
-        foreach (var name in LINUX_FLUIDSYNTH_ABI_V2_DLL_NAMES)
-        {
-            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
-                continue;
+        _ = TryLoadDll(assembly, path, LINUX_FLUIDSYNTH_ABI_V2_DLL_NAMES, out handle);
 
-            return handle;
-        }
-
-        return IntPtr.Zero;
+        return handle;
     }
 
     private static IntPtr TryLoadOsx(System.Reflection.Assembly assembly, DllImportSearchPath? path)
@@ -98,25 +88,15 @@ internal static partial class LibFluidsynth
 
     private static IntPtr TryLoadWindows(System.Reflection.Assembly assembly, DllImportSearchPath? path)
     {
-        foreach (var name in WINDOWS_FLUIDSYNTH_ABI_V3_DLL_NAMES)
-        {
-            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
-                continue;
-
+        if (TryLoadDll(assembly, path, WINDOWS_FLUIDSYNTH_ABI_V3_DLL_NAMES, out var handle)) {
             LibraryVersion = FluidSynthAbiVersion.V3;
 
             return handle;
         }
 
-        foreach (var name in WINDOWS_FLUIDSYNTH_ABI_V2_DLL_NAMES)
-        {
-            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
-                continue;
+        _ = TryLoadDll(assembly, path, WINDOWS_FLUIDSYNTH_ABI_V2_DLL_NAMES, out handle);
 
-            return handle;
-        }
-
-        return IntPtr.Zero;
+        return handle;
     }
 
     private static bool TryLoadDll(

--- a/NFluidsynth/Native/LibFluidsynth.cs
+++ b/NFluidsynth/Native/LibFluidsynth.cs
@@ -1,75 +1,142 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace NFluidsynth.Native
+// ReSharper disable LoopCanBeConvertedToQuery
+
+namespace NFluidsynth.Native;
+
+public enum FluidSynthAbiVersion : uint {
+    V2 = 2,
+    V3 = 3
+}
+
+internal static partial class LibFluidsynth
 {
-    internal static partial class LibFluidsynth
-    {
-        public const string LibraryName = "fluidsynth";
+    public const int FluidOk = 0;
+    public const int FluidFailed = -1;
+    public const string LibraryName = "fluidsynth";
 
-        // Supports both ABI 2 and ABI 3 of Fluid Synth
-        // https://abi-laboratory.pro/index.php?view=timeline&l=fluidsynth
-        public static int LibraryVersion 
-        { 
-            get
-            {
-                return _libraryVersion;
-            }
-            
-            private set
-            {
-                _libraryVersion = value;
-            }
-        }
-        private static int _libraryVersion = 2; // Assume using ABI 2 unless detecting otherwise
+    // Assumption here is that this binds against whatever API .3 is,
+    //  but will try the general name anyway just in case.
+    private static readonly string[] LINUX_FLUIDSYNTH_ABI_V3_DLL_NAMES = ["libfluidsynth.so.3"];
+    private static readonly string[] LINUX_FLUIDSYNTH_ABI_V2_DLL_NAMES = ["libfluidsynth.so.2", "libfluidsynth.so"];
+    private static readonly string[] OSX_FLUIDSYNTH_DLL_NAMES = ["libfluidsynth.dylib"];
 
-        public const int FluidOk = 0;
-        public const int FluidFailed = -1;
+    private static readonly string[] WINDOWS_FLUIDSYNTH_ABI_V3_DLL_NAMES = ["libfluidsynth-3"];
+    private static readonly string[] WINDOWS_FLUIDSYNTH_ABI_V2_DLL_NAMES =
+    [
+        "libfluidsynth-2",
+        "fluidsynth",
+        "libfluidsynth"
+    ];
+
+    // Supports both ABI 2 and ABI 3 of FluidSynth
+    // https://abi-laboratory.pro/index.php?view=timeline&l=fluidsynth
+    public static FluidSynthAbiVersion LibraryVersion { get; private set; } = FluidSynthAbiVersion.V2;
 
 #if NETCOREAPP
-        static LibFluidsynth()
+    static LibFluidsynth()
+    {
+        try
         {
-            try
+            NativeLibrary.SetDllImportResolver(typeof(LibFluidsynth).Assembly, (name, assembly, path) =>
             {
-                NativeLibrary.SetDllImportResolver(typeof(LibFluidsynth).Assembly, (name, assembly, path) =>
-                {
-                    IntPtr handle;
-                    if (name == LibraryName)
-                    {
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                        {
-                            // Assumption here is that this binds against whatever API .3 is,
-                            //  but will try the general name anyway just in case.
-                            if (NativeLibrary.TryLoad("libfluidsynth.so.3", assembly, path, out handle))
-                            {
-                                LibFluidsynth.LibraryVersion = 3;
-                                return handle;
-                            }
-
-                            if (NativeLibrary.TryLoad("libfluidsynth.so.2", assembly, path, out handle))
-                                return handle;
-
-                            if (NativeLibrary.TryLoad("libfluidsynth.so", assembly, path, out handle))
-                                return handle;
-                        }
-
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                        {
-                            if (NativeLibrary.TryLoad("libfluidsynth.dylib", assembly, path, out handle))
-                                return handle;
-                        }
-                    }
-
+                if (name != LibraryName)
                     return IntPtr.Zero;
-                });
-            }
-            catch (Exception)
-            {
-                // An exception can be thrown in the above call if someone has already set a DllImportResolver.
-                // (Can occur if the application wants to override behaviour.)
-                // This does not throw away failures to resolve.
-            }
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    return TryLoadLinux(assembly, path);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    return TryLoadOsx(assembly, path);
+
+                // ReSharper disable once ConvertIfStatementToReturnStatement
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    return TryLoadWindows(assembly, path);
+
+                return IntPtr.Zero;
+            });
         }
-#endif
+        catch (Exception)
+        {
+            // An exception can be thrown in the above call if someone has already set a DllImportResolver.
+            // (Can occur if the application wants to override behaviour.)
+            // This does not throw away failures to resolve.
+        }
     }
+
+    private static IntPtr TryLoadLinux(System.Reflection.Assembly assembly, DllImportSearchPath? path)
+    {
+        foreach (var name in LINUX_FLUIDSYNTH_ABI_V3_DLL_NAMES)
+        {
+            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
+                continue;
+
+            LibraryVersion = FluidSynthAbiVersion.V3;
+
+            return handle;
+        }
+
+        foreach (var name in LINUX_FLUIDSYNTH_ABI_V2_DLL_NAMES)
+        {
+            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
+                continue;
+
+            return handle;
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static IntPtr TryLoadOsx(System.Reflection.Assembly assembly, DllImportSearchPath? path)
+    {
+        _ = TryLoadDll(assembly, path, OSX_FLUIDSYNTH_DLL_NAMES, out var handle);
+
+        return handle;
+    }
+
+
+    private static IntPtr TryLoadWindows(System.Reflection.Assembly assembly, DllImportSearchPath? path)
+    {
+        foreach (var name in WINDOWS_FLUIDSYNTH_ABI_V3_DLL_NAMES)
+        {
+            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
+                continue;
+
+            LibraryVersion = FluidSynthAbiVersion.V3;
+
+            return handle;
+        }
+
+        foreach (var name in WINDOWS_FLUIDSYNTH_ABI_V2_DLL_NAMES)
+        {
+            if (!NativeLibrary.TryLoad(name, assembly, path, out var handle))
+                continue;
+
+            return handle;
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private static bool TryLoadDll(
+        System.Reflection.Assembly assembly,
+        DllImportSearchPath? path,
+        string[] names,
+        out IntPtr handle
+    )
+    {
+        foreach (var name in names)
+        {
+            if (!NativeLibrary.TryLoad(name, assembly, path, out handle))
+                continue;
+
+            return true;
+        }
+
+        handle = IntPtr.Zero;
+
+        return false;
+    }
+#endif
 }

--- a/NFluidsynth/SequencerEvent.cs
+++ b/NFluidsynth/SequencerEvent.cs
@@ -106,7 +106,7 @@ namespace NFluidsynth
             {
                 ThrowIfDisposed();
 
-                if (LibFluidsynth.LibraryVersion == 2)
+                if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                     return LibFluidsynth.fluid_event_get_value_2(Handle);
                 else 
                     return LibFluidsynth.fluid_event_get_value_3(Handle);
@@ -119,7 +119,7 @@ namespace NFluidsynth
             {
                 ThrowIfDisposed();
 
-                if (LibFluidsynth.LibraryVersion == 2)
+                if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                     return LibFluidsynth.fluid_event_get_program_2(Handle);
                 else
                     return LibFluidsynth.fluid_event_get_program_3(Handle);
@@ -217,7 +217,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
             
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_program_change_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_program_change_3(Handle, channel, val);
@@ -233,7 +233,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
             
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_control_change_2(Handle, channel, control, val);
             else
                 LibFluidsynth.fluid_event_control_change_3(Handle, channel, control, val);
@@ -249,7 +249,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_pitch_wheelsens_2(Handle, channel, value);
             else
                 LibFluidsynth.fluid_event_pitch_wheelsens_3(Handle, channel, value);
@@ -259,7 +259,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_modulation_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_modulation_3(Handle, channel, val);
@@ -269,7 +269,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_sustain_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_sustain_3(Handle, channel, val);
@@ -279,7 +279,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_pan_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_pan_3(Handle, channel, val);
@@ -289,7 +289,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_volume_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_volume_3(Handle, channel, val);
@@ -299,7 +299,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_reverb_send_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_reverb_send_3(Handle, channel, val);
@@ -309,7 +309,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_chorus_send_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_chorus_send_3(Handle, channel, val);
@@ -319,7 +319,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_key_pressure_2(Handle, channel, key, val);
             else
                 LibFluidsynth.fluid_event_key_pressure_3(Handle, channel, key, val);
@@ -329,7 +329,7 @@ namespace NFluidsynth
         {
             ThrowIfDisposed();
 
-            if (LibFluidsynth.LibraryVersion == 2)
+            if (LibFluidsynth.LibraryVersion is FluidSynthAbiVersion.V2)
                 LibFluidsynth.fluid_event_channel_pressure_2(Handle, channel, val);
             else
                 LibFluidsynth.fluid_event_channel_pressure_3(Handle, channel, val);

--- a/NFluidsynth/SoundFontLoader.cs
+++ b/NFluidsynth/SoundFontLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using NFluidsynth.Native;
 using static NFluidsynth.Native.LibFluidsynth;
 
 namespace NFluidsynth
@@ -68,7 +69,7 @@ namespace NFluidsynth
 
         public unsafe void SetCallbacks(SoundFontLoaderCallbacks callbacks)
         {
-            if (LibraryVersion == 2)
+            if (LibraryVersion is FluidSynthAbiVersion.V2)
             {
                 fluid_sfloader_set_callbacks(handle,
                     Utility.PassDelegatePointer(callbacks.Open, out _open),

--- a/NFluidsynth/Synth.cs
+++ b/NFluidsynth/Synth.cs
@@ -32,20 +32,17 @@ namespace NFluidsynth
         public void NoteOn(int channel, int key, int vel)
         {
             ThrowIfDisposed();
-            if (LibFluidsynth.fluid_synth_noteon(Handle, channel, key, vel) != 0)
-            {
-                OnError("noteon operation failed");
-            }
+
+            // This can return 1, representing FS not being able to action the command, but this is expected given MIDIs can be arbitrary;
+            LibFluidsynth.fluid_synth_noteon(Handle, channel, key, vel);
         }
 
         public void NoteOff(int channel, int key)
         {
             ThrowIfDisposed();
-            // not sure if we should always raise exception, it seems that it also returns FLUID_FAILED for not-on-state note.
-            if (LibFluidsynth.fluid_synth_noteoff(Handle, channel, key) != 0)
-            {
-                OnError("noteoff operation failed");
-            }
+
+            // This can return 1, representing FS not being able to action the command, but this is expected given MIDIs can be arbitrary.
+            LibFluidsynth.fluid_synth_noteoff(Handle, channel, key);
         }
 
         public void CC(int channel, int num, int val)
@@ -68,20 +65,21 @@ namespace NFluidsynth
             return ret;
         }
 
-        #if NETCOREAPP
-        public unsafe bool Sysex (ReadOnlySpan<byte> input, Span<byte> output, bool dryRun = false)
+#if NETCOREAPP
+        public unsafe bool Sysex(ReadOnlySpan<byte> input, Span<byte> output, bool dryRun = false)
         {
             fixed (byte* iPtr = input)
             fixed (byte* oPtr = output)
-                return Sysex ((IntPtr) iPtr, input.Length, (IntPtr) oPtr, output.Length, dryRun);
+                return Sysex((IntPtr)iPtr, input.Length, (IntPtr)oPtr, output.Length, dryRun);
         }
-        #endif
+#endif
 
-        public unsafe bool Sysex (byte [] input, int inputOffset, int inputLength, byte [] output, int outputOffset, int outputLength, bool dryRun = false)
+        public unsafe bool Sysex(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset,
+            int outputLength, bool dryRun = false)
         {
             fixed (byte* iPtr = input)
             fixed (byte* oPtr = output)
-                return Sysex ((IntPtr) iPtr, inputLength, (IntPtr) oPtr, outputLength, dryRun);
+                return Sysex((IntPtr)iPtr, inputLength, (IntPtr)oPtr, outputLength, dryRun);
         }
 
         public bool Sysex(IntPtr input, int inputLength, IntPtr output, int outputLength, bool dryRun = false)
@@ -89,13 +87,17 @@ namespace NFluidsynth
             ThrowIfDisposed();
 
             int outLen = outputLength;
-            unsafe {
-                if (LibFluidsynth.fluid_synth_sysex (Handle, (byte*) input, inputLength, (byte*) output, ref outLen, out var handled, dryRun) != 0) {
-                    if (outLen != 0) {
-                        OnError ("Output buffer is too small");
+            unsafe
+            {
+                if (LibFluidsynth.fluid_synth_sysex(Handle, (byte*)input, inputLength, (byte*)output, ref outLen,
+                        out var handled, dryRun) != 0)
+                {
+                    if (outLen != 0)
+                    {
+                        OnError("Output buffer is too small");
                     }
 
-                    OnError ("sysex operation failed");
+                    OnError("sysex operation failed");
                 }
 
                 return handled;
@@ -268,7 +270,7 @@ namespace NFluidsynth
             if (result < 0)
                 OnError("sound font load operation failed");
 
-            return (uint) result;
+            return (uint)result;
         }
 
         public void ReloadSoundFont(uint id)
@@ -559,18 +561,19 @@ namespace NFluidsynth
 
         #region Tuning
 
-        #if NETCOREAPP
-        public unsafe void ActivateKeyTuning (int bank, int prog, string name, ReadOnlySpan<double> pitch, bool apply)
+#if NETCOREAPP
+        public unsafe void ActivateKeyTuning(int bank, int prog, string name, ReadOnlySpan<double> pitch, bool apply)
         {
             fixed (double* pPtr = pitch)
-                ActivateKeyTuning (bank, prog, name, (IntPtr) pPtr, pitch.Length, apply);
+                ActivateKeyTuning(bank, prog, name, (IntPtr)pPtr, pitch.Length, apply);
         }
-        #endif
+#endif
 
-        public unsafe void ActivateKeyTuning (int bank, int prog, string name, double [] pitch, int pitchOffset, int pitchLength, bool apply)
+        public unsafe void ActivateKeyTuning(int bank, int prog, string name, double[] pitch, int pitchOffset,
+            int pitchLength, bool apply)
         {
             fixed (double* pPtr = pitch)
-                ActivateKeyTuning (bank, prog, name, (IntPtr) (pPtr + pitchOffset), pitchLength, apply);
+                ActivateKeyTuning(bank, prog, name, (IntPtr)(pPtr + pitchOffset), pitchLength, apply);
         }
 
         public void ActivateKeyTuning(int bank, int prog, string name, IntPtr pitch, int pitchLength, bool apply)
@@ -583,26 +586,27 @@ namespace NFluidsynth
 
             unsafe
             {
-                if (LibFluidsynth.fluid_synth_activate_key_tuning(Handle, bank, prog, name, (double*) pitch, apply) != 0)
+                if (LibFluidsynth.fluid_synth_activate_key_tuning(Handle, bank, prog, name, (double*)pitch, apply) != 0)
                 {
                     OnError("key tuning create operation failed");
                 }
             }
         }
 
-        #if NETCOREAPP
-        public unsafe void ActivateOctaveTuning (int bank, int prog, string name, ReadOnlySpan<double> pitch,
+#if NETCOREAPP
+        public unsafe void ActivateOctaveTuning(int bank, int prog, string name, ReadOnlySpan<double> pitch,
             bool apply)
         {
             fixed (double* pPtr = pitch)
-                ActivateOctaveTuning (bank, prog, name, (IntPtr) pPtr, pitch.Length, apply);
+                ActivateOctaveTuning(bank, prog, name, (IntPtr)pPtr, pitch.Length, apply);
         }
-        #endif
+#endif
 
-        public unsafe void ActivateOctaveTuning (int bank, int prog, string name, double [] pitch, int pitchOffset, int pitchLength, bool apply)
+        public unsafe void ActivateOctaveTuning(int bank, int prog, string name, double[] pitch, int pitchOffset,
+            int pitchLength, bool apply)
         {
             fixed (double* pPtr = pitch)
-                ActivateOctaveTuning (bank, prog, name, (IntPtr) (pPtr + pitchOffset), pitchLength, apply);
+                ActivateOctaveTuning(bank, prog, name, (IntPtr)(pPtr + pitchOffset), pitchLength, apply);
         }
 
         public void ActivateOctaveTuning(int bank, int prog, string name, IntPtr pitch, int pitchLength, bool apply)
@@ -615,30 +619,34 @@ namespace NFluidsynth
 
             unsafe
             {
-                if (LibFluidsynth.fluid_synth_activate_octave_tuning(Handle, bank, prog, name, (double*) pitch, apply) != 0)
+                if (LibFluidsynth.fluid_synth_activate_octave_tuning(Handle, bank, prog, name, (double*)pitch, apply) !=
+                    0)
                     OnError("key tuning create operation failed");
             }
         }
 
-        #if NETCOREAPP
-        public unsafe void TuneNotes (int bank, int prog, ReadOnlySpan<int> keys, ReadOnlySpan<double> pitch,
+#if NETCOREAPP
+        public unsafe void TuneNotes(int bank, int prog, ReadOnlySpan<int> keys, ReadOnlySpan<double> pitch,
             bool apply)
         {
             fixed (int* kPtr = keys)
             fixed (double* pPtr = pitch)
-                TuneNotes (bank, prog, (IntPtr) kPtr, keys.Length, (IntPtr) pPtr, pitch.Length, apply);
+                TuneNotes(bank, prog, (IntPtr)kPtr, keys.Length, (IntPtr)pPtr, pitch.Length, apply);
         }
-        #endif
+#endif
 
-        public unsafe void TuneNotes (int bank, int prog, int [] keys, int keysOffset, int keysLength, double [] pitch, int pitchOffset, int pitchLength,
+        public unsafe void TuneNotes(int bank, int prog, int[] keys, int keysOffset, int keysLength, double[] pitch,
+            int pitchOffset, int pitchLength,
             bool apply)
         {
             fixed (int* kPtr = keys)
             fixed (double* pPtr = pitch)
-                TuneNotes (bank, prog, (IntPtr) (kPtr + keysOffset), keysLength, (IntPtr) (pPtr + pitchOffset), pitchLength, apply);
+                TuneNotes(bank, prog, (IntPtr)(kPtr + keysOffset), keysLength, (IntPtr)(pPtr + pitchOffset),
+                    pitchLength, apply);
         }
 
-        public void TuneNotes(int bank, int prog, IntPtr keys, int keysLength, IntPtr pitch, int pitchLength, bool apply)
+        public void TuneNotes(int bank, int prog, IntPtr keys, int keysLength, IntPtr pitch, int pitchLength,
+            bool apply)
         {
             ThrowIfDisposed();
             if (keysLength != 128)
@@ -653,7 +661,8 @@ namespace NFluidsynth
 
             unsafe
             {
-                if (LibFluidsynth.fluid_synth_tune_notes(Handle, bank, prog, keysLength, (int*) keys, (double*) pitch, apply) != 0)
+                if (LibFluidsynth.fluid_synth_tune_notes(Handle, bank, prog, keysLength, (int*)keys, (double*)pitch,
+                        apply) != 0)
                 {
                     OnError("key tuning create operation failed");
                 }
@@ -713,24 +722,25 @@ namespace NFluidsynth
             }
         }
 
-        #if NETCOREAPP
-        public unsafe void WriteSample16 (int count, Span<ushort> leftOut, int leftOffset, int leftIncrement,
+#if NETCOREAPP
+        public unsafe void WriteSample16(int count, Span<ushort> leftOut, int leftOffset, int leftIncrement,
             Span<ushort> rightOut, int rightOffset, int rightIncrement)
         {
             fixed (ushort* lPtr = leftOut)
             fixed (ushort* rPtr = rightOut)
-                WriteSample16 (count, (IntPtr) lPtr, leftOffset, leftOut.Length, leftIncrement,
-                    (IntPtr) rPtr, rightOffset, rightOut.Length, rightIncrement);
+                WriteSample16(count, (IntPtr)lPtr, leftOffset, leftOut.Length, leftIncrement,
+                    (IntPtr)rPtr, rightOffset, rightOut.Length, rightIncrement);
         }
-        #endif
+#endif
 
-        public unsafe void WriteSample16 (int count, ushort [] leftOut, int leftOffset, int leftOutLength, int leftIncrement,
-            ushort [] rightOut, int rightOffset, int rightOutLength, int rightIncrement)
+        public unsafe void WriteSample16(int count, ushort[] leftOut, int leftOffset, int leftOutLength,
+            int leftIncrement,
+            ushort[] rightOut, int rightOffset, int rightOutLength, int rightIncrement)
         {
             fixed (ushort* lPtr = leftOut)
             fixed (ushort* rPtr = rightOut)
-                WriteSample16 (count, (IntPtr) lPtr, leftOffset, leftOut.Length, leftIncrement,
-                    (IntPtr) rPtr, rightOffset, rightOut.Length, rightIncrement);
+                WriteSample16(count, (IntPtr)lPtr, leftOffset, leftOut.Length, leftIncrement,
+                    (IntPtr)rPtr, rightOffset, rightOut.Length, rightIncrement);
         }
 
         public void WriteSample16(int count, IntPtr leftOut, int leftOffset, int leftOutLength, int leftIncrement,
@@ -753,33 +763,33 @@ namespace NFluidsynth
 
             unsafe
             {
-                if (LibFluidsynth.fluid_synth_write_s16(Handle, count, (ushort*) leftOut, leftOffset, leftIncrement,
-                        (ushort*) rightOut, rightOffset, rightIncrement) != 0)
+                if (LibFluidsynth.fluid_synth_write_s16(Handle, count, (ushort*)leftOut, leftOffset, leftIncrement,
+                        (ushort*)rightOut, rightOffset, rightIncrement) != 0)
                 {
                     OnError("16bit sample write operation failed");
                 }
             }
         }
 
-        #if NETCOREAPP
-        public unsafe void WriteSampleFloat (int count, Span<float> leftOut, int leftOffset, int leftIncrement,
+#if NETCOREAPP
+        public unsafe void WriteSampleFloat(int count, Span<float> leftOut, int leftOffset, int leftIncrement,
             Span<float> rightOut, int rightOffset, int rightIncrement)
         {
             fixed (float* lPtr = leftOut)
             fixed (float* rPtr = rightOut)
-                WriteSampleFloat (count, (IntPtr) lPtr, leftOffset, leftOut.Length, leftIncrement,
-                    (IntPtr) rPtr, rightOffset, rightOut.Length, rightIncrement);
-
+                WriteSampleFloat(count, (IntPtr)lPtr, leftOffset, leftOut.Length, leftIncrement,
+                    (IntPtr)rPtr, rightOffset, rightOut.Length, rightIncrement);
         }
-        #endif
+#endif
 
-        public unsafe void WriteSampleFloat(int count, float [] leftOut, int leftOffset, int leftOutLength, int leftIncrement,
-            float [] rightOut, int rightOffset, int rightOutLength, int rightIncrement)
+        public unsafe void WriteSampleFloat(int count, float[] leftOut, int leftOffset, int leftOutLength,
+            int leftIncrement,
+            float[] rightOut, int rightOffset, int rightOutLength, int rightIncrement)
         {
             fixed (float* lPtr = leftOut)
             fixed (float* rPtr = rightOut)
-                WriteSampleFloat (count, (IntPtr) lPtr, leftOffset, leftOut.Length, leftIncrement,
-                    (IntPtr) rPtr, rightOffset, rightOut.Length, rightIncrement);
+                WriteSampleFloat(count, (IntPtr)lPtr, leftOffset, leftOut.Length, leftIncrement,
+                    (IntPtr)rPtr, rightOffset, rightOut.Length, rightIncrement);
         }
 
         public void WriteSampleFloat(int count, IntPtr leftOut, int leftOffset, int leftOutLength, int leftIncrement,
@@ -802,8 +812,8 @@ namespace NFluidsynth
 
             unsafe
             {
-                if (LibFluidsynth.fluid_synth_write_float(Handle, count, (float*) leftOut, leftOffset, leftIncrement,
-                        (float*) rightOut, rightOffset, rightIncrement) != 0)
+                if (LibFluidsynth.fluid_synth_write_float(Handle, count, (float*)leftOut, leftOffset, leftIncrement,
+                        (float*)rightOut, rightOffset, rightIncrement) != 0)
                     OnError("float sample write operation failed");
             }
         }
@@ -816,6 +826,7 @@ namespace NFluidsynth
                 // Why would you want to? No idea!
                 return 0;
             }
+
             return 1 + (count - 1) * increment + offset;
         }
 

--- a/NFluidsynth/Synth.cs
+++ b/NFluidsynth/Synth.cs
@@ -32,17 +32,20 @@ namespace NFluidsynth
         public void NoteOn(int channel, int key, int vel)
         {
             ThrowIfDisposed();
-
-            // This can return 1, representing FS not being able to action the command, but this is expected given MIDIs can be arbitrary;
-            LibFluidsynth.fluid_synth_noteon(Handle, channel, key, vel);
+            if (LibFluidsynth.fluid_synth_noteon(Handle, channel, key, vel) != 0)
+            {
+                OnError("noteon operation failed");
+            }
         }
 
         public void NoteOff(int channel, int key)
         {
             ThrowIfDisposed();
-
-            // This can return 1, representing FS not being able to action the command, but this is expected given MIDIs can be arbitrary.
-            LibFluidsynth.fluid_synth_noteoff(Handle, channel, key);
+            // not sure if we should always raise exception, it seems that it also returns FLUID_FAILED for not-on-state note.
+            if (LibFluidsynth.fluid_synth_noteoff(Handle, channel, key) != 0)
+            {
+                OnError("noteoff operation failed");
+            }
         }
 
         public void CC(int channel, int num, int val)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ NFluidsynth is a C# binding for [libfluidsynth](https://github.com/Fluidsynth/fl
 It is a P/Invoke wrapper, therefore you need native libfluidsynth.so / libfluidsynth.dylib / (lib)fluidsynth.dll.
 NFluidsynth builds and packages don't come up with those native libraries, so you are supposed to prepare them by yourself (at least for now).
 
-The target API is fluidsynth 2.0.x. The API mappings may not be complete (contributions are welcome).
+The target API is Fluidsynth 2.1.x. The API mappings may not be complete (contributions are welcome).
 
 Used mainly in [RobustToolbox](https://github.com/space-wizards/RobustToolbox) for MIDI input and playback support.
+
+## How to Run This Project
+
+1. Get the supported version of FluidSynth (currently 2.1.0.0) [from the FluidSynth repo](https://github.com/FluidSynth/fluidsynth/releases). Get the one for your operating system.
+2. Clone this Git repo.
+3. Open the downloaded Fluidsynth release. Open the /bin/ folder.
+4. Copy everything from the /bin/ folder into the root of the repo (other than the Fluidsynth executable)
+5. Run `dotnet run --project NFluidsynth.Sample`
+
+You should now have a working test-bench for NFluidsynth.
+


### PR DESCRIPTION
* Updated the project to dotnet 9.0
* Removed redundant boilerplate in FluidSynthInteropException (?)
* Allowed Windows to use ABI v3 files if the DLL exists.
* Made sure that the ABI version var is an enum not just a magic var.
* Allowed Windows to load ABI V3 DLLs (called `libfluidsynth-3`)
* Modernized LibFluidSynth's declaration a bit.
* Updated the sample project and added instructions on how to run it to the readme.

